### PR TITLE
Add less-rails as a runtime dependency

### DIFF
--- a/bootstrap-on-rails.gemspec
+++ b/bootstrap-on-rails.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.licenses = ["Apache v2"]
 
+  s.add_dependency "less-rails"
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
   # s.add_runtime_dependency "railties"

--- a/lib/bootstrap-on-rails.rb
+++ b/lib/bootstrap-on-rails.rb
@@ -1,4 +1,5 @@
 require "bootstrap-on-rails/version"
+require "less-rails"
 
 module BootstrapOnRails
   require "bootstrap-on-rails/engine"


### PR DESCRIPTION
This lets you not have to require less-rails as a runtime dependency in your app.
