### PR TITLE
Removes the asset_url in calling the glyphicons

### DIFF
--- a/app/assets/stylesheets/bootstrap/glyphicons.less
+++ b/app/assets/stylesheets/bootstrap/glyphicons.less
@@ -10,11 +10,11 @@
 // Import the fonts
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: asset-url('@{icon-font-path}@{icon-font-name}.eot');
-  src: asset-url('@{icon-font-path}@{icon-font-name}.eot?#iefix') format('embedded-opentype'),
-       asset-url('@{icon-font-path}@{icon-font-name}.woff') format('woff'),
-       asset-url('@{icon-font-path}@{icon-font-name}.ttf') format('truetype'),
-       asset-url('@{icon-font-path}@{icon-font-name}.svg#@{icon-font-svg-id}') format('svg');
+  src: '@{icon-font-path}@{icon-font-name}.eot';
+  src: '@{icon-font-path}@{icon-font-name}.eot?#iefix' format('embedded-opentype'),
+       '@{icon-font-path}@{icon-font-name}.woff' format('woff'),
+       '@{icon-font-path}@{icon-font-name}.ttf' format('truetype'),
+       '@{icon-font-path}@{icon-font-name}.svg#@{icon-font-svg-id}' format('svg');
 }
 
 // Catchall baseclass


### PR DESCRIPTION
Fixes this issue below which is happening in Rails 4.1.6:
ActionView::Template::Error (error evaluating function `asset-url`: Asset names passed to helpers should not include the "/assets/" prefix. Instead of "/assets/bootstrap/glyphicons-halflings-regular.eot", use "bootstrap/glyphicons-halflings-regular.eot"
